### PR TITLE
Update deprecated name RadicalGroup.

### DIFF
--- a/gap/nicestab.gi
+++ b/gap/nicestab.gi
@@ -93,7 +93,7 @@ BindGlobal( "TrySolvableSubgroup", function( A )
     phom := GroupHomomorphismByImagesNC( B, P, A.glAutos, A.glOper );
 
     # get normal subgroup
-    N := RadicalGroup( P );
+    N := SolvableRadical( P );
     pcgs := Pcgs( N ); 
     Info( InfoAutGrp, 4, "  found pcgs of length ", Length(pcgs));
     if Length(pcgs) = 0 then return; fi;


### PR DESCRIPTION
Hi, I was getting this error message when importing autpgrp
```
Syntax warning: Unbound global variable in /usr/share/gap/pkg/autpgrp/gap/nicestab.gi:96
    N := RadicalGroup( P );
         ^^^^^^^^^^^^
```