### PR TITLE
Fix an issue in TrySolvableSubgroup affecting anupq

### DIFF
--- a/gap/nicestab.gi
+++ b/gap/nicestab.gi
@@ -80,7 +80,7 @@ end );
 #F TrySolvableSubgroup( A )
 ##
 BindGlobal( "TrySolvableSubgroup", function( A )
-    local P, B, N, pcgs, phom, nhom, G, auts, gens;
+    local P, B, N, pcgs, phom, nhom, G, auts, gens, phominv;
 
     Info( InfoAutGrp, 4, "  try solvable normal subgroup");
 
@@ -103,7 +103,8 @@ BindGlobal( "TrySolvableSubgroup", function( A )
     G := ImagesSource( nhom );
 
     # get ag part
-    auts := List( pcgs, x -> PreImagesRepresentative( phom,x ) );
+    phominv := InverseGeneralMapping( phom) ;
+    auts := List(pcgs, x -> ImagesRepresentative( phominv, x ) );
     A.agAutos := Concatenation( auts, A.agAutos );
     A.agOrder := Concatenation( RelativeOrders( pcgs ), A.agOrder );
 


### PR DESCRIPTION
This resolves https://github.com/gap-packages/anupq/issues/67 where the following code would get stuck in the last line:

    LoadPackage("anupq");;
    G:=SmallGroup(512,383371);;
    H:=SmallGroup(512,383419);;
    PqStandardPresentation(G);
    PqStandardPresentation(H);

See https://github.com/gap-packages/anupq/issues/67#issuecomment-2812739952 where @beick described this fix which was suggested by @hulpke