### PR TITLE
Dont pass package name to AutoDoc()

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -20,7 +20,7 @@ includes := [
 
 # The actual call to AutoDoc
 
-AutoDoc("AutPGrp", rec(
+AutoDoc(rec(
     autodoc := rec(scan_dirs := []),
     gapdoc  := rec(main := "main.xml", files := []),
     extract_examples := true,


### PR DESCRIPTION
This has been deprecated for many years.
