### PR TITLE
Don't call `MaxSubIntersections` if `IdGroup` is not available

### DIFF
--- a/gap/initmat.gi
+++ b/gap/initmat.gi
@@ -100,10 +100,11 @@ end );
 #F PGCharSubgroups( G )
 ##
 BindGlobal( "PGCharSubgroups", function(G)
-    local  cent, omega;
+    local  cent, omega, size;
     cent := TwoStepCentralizersByLcs( G );
     omega := OmegaSubgroupsByLcs( G );
-    if Size(G) <= 512 then 
+    size := Size( G );
+    if size <= 512 and ID_AVAILABLE( size ) <> fail then 
         return Union(cent, omega, MaxSubIntersections(G));
     else
         return Union( cent, omega );


### PR DESCRIPTION
Context: https://github.com/gap-system/gap/issues/2434

The function `MaxSubIntersections` currently assumes that `IdGroup` is available whenever it is called. And the function `PGCharSubgroups` calls `MaxSubIntersections( G )` if `G` has size at most 512, so everything works fine if the `SmallGrp` package is loaded... but this causes an error when it's not.

This PR adds a check to see if `IdGroup` really is available, in addition to the size constraint.