### PR TITLE
Try to prevent a bug in `TrySolvableSubgroup`

### DIFF
--- a/gap/hybrstab.gi
+++ b/gap/hybrstab.gi
@@ -287,8 +287,10 @@ BindGlobal( "BlockOrbitStabilizer", function( B, oper, os, fpt, info )
                     g := Transform( get, pers, () );
                     if not g in stabGrp then
                         stabGrp := ClosureGroup( stabGrp, g );
-                        Add( pstab, g );
-                        Add( stabl, aut );
+                        if not IsOne( aut ) then
+                            Add( pstab, g );
+                            Add( stabl, aut );
+                        fi;
                     fi;
                 else
                     Add( stabl, aut );


### PR DESCRIPTION
An attempt to solve https://github.com/gap-packages/anupq/issues/67. Making this a draft PR because, bluntly, I have **no idea** if this is actually correct.

A bit on the bug: it seems that `TrySolvableGroup` sometimes gets passed a faulty record `A`. In such cases, `A.glOper` contains a non-trivial permutation, but the corresponding element in `A.glAutos` is actually the identity automorphism.

https://github.com/gap-packages/autpgrp/blob/dab4d912dd45633b091f6dec4d3331fd4e860488/gap/nicestab.gi#L88-L93

This means that `phom` as created above is not actually a group homomorphism, since it maps the identity of `B` to a non-identity element of `P`. But since we're using the `NC` version of `GroupHomomorphismByImages`, this doesn't get detected. But later, we try to get preimages of elements under `phom`:

https://github.com/gap-packages/autpgrp/blob/dab4d912dd45633b091f6dec4d3331fd4e860488/gap/nicestab.gi#L106

And this is where the code (sometimes) hangs.

So, I traced the faulty values for `A.glOper` and `A.glAutos` as being set in `PGHybridOrbitStabilizer`, but those values were actually calculated by `BlockOrbitStabilizer`. I then essentially just messed around with that function until I got something that still passed the CI tests and no longer creates `phom`'s that aren't group homomorphisms.

So uhh, yeah, it would probably be best if someone that actually understands the underlying algorithms has a look at this before it gets merged...