### PR TITLE
Add `PcSubAutPGroup`

### DIFF
--- a/gap/autos.gd
+++ b/gap/autos.gd
@@ -47,6 +47,7 @@ DeclareOperation( "PGMultList", [IsList] );
 ##
 DeclareGlobalFunction( "ImageAutPGroup" );
 DeclareGlobalFunction( "InnerAutGroupPGroup" );
+DeclareGlobalFunction( "PcSubAutPGroup" );
 DeclareGlobalFunction( "ConvertAutGroup" );
 DeclareGlobalFunction( "InduceAutGroup" );
 DeclareGlobalFunction( "LinearActionAutGrp" );

--- a/gap/pcpres.gi
+++ b/gap/pcpres.gi
@@ -183,3 +183,14 @@ InstallGlobalFunction( InnerAutGroupPGroup,
     I := Subgroup(C, imgs );
     return I;
   end);
+
+#############################################################################
+##
+#F PcSubAutPGroup( C, A ). . .  embed A, a subgroup of Aut(G), into pc group
+##
+InstallGlobalFunction( PcSubAutPGroup, 
+  function(C, A)
+    local L;
+    L := List(GeneratorsOfGroup(A), x -> ImageAutPGroup(C!.autrec, C, x));
+    return Subgroup(C, L);
+  end);


### PR DESCRIPTION
Added a function `PcSubAutPGroup` that embeds a subgroup of the automorphism group into a subgroup of the pc-representation of the automorphism group. This generalises the function `InnerAutGroupPGroup`.